### PR TITLE
Update currently supported Ubuntu versions

### DIFF
--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -189,8 +189,8 @@ jobs:
         client_image:
           - "debian:bookworm"
           - "debian:bullseye"
+          - "ubuntu:24.04"
           - "ubuntu:22.04"
-          - "ubuntu:20.04"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Remove Ubuntu 20:04 from tests and add Ubuntu 24.04.

Closes #49.