### PR TITLE
Add PR CI Gate aggregating Hadolint, ShellCheck, and Upstream Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,6 +543,27 @@ jobs:
             sarif_file: results.sarif
             category: results
 
+  hadolint:
+    name: Hadolint
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/hadolint.yml
+    permissions:
+      contents: read
+
+  shellcheck:
+    name: ShellCheck
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/shellcheck.yml
+    permissions:
+      contents: read
+
+  upstream-compatibility:
+    name: Upstream Compatibility Tests
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/upstream-compatibility.yml
+    permissions:
+      contents: read
+
   build-and-push-docker-image:
     name: Build and Push Docker Image
     needs: [test-integration, scan-image]
@@ -676,3 +697,50 @@ jobs:
           # curl -X POST -H 'Content-type: application/json' \
           #   --data '{"text":"apt-cacher-ng scheduled build failed!"}' \
           #   $SLACK_WEBHOOK_URL
+
+  pr-ci-gate:
+    name: PR CI Gate
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - build-test-image
+      - test-integration
+      - scan-image
+      - build-and-push-docker-image
+      - hadolint
+      - shellcheck
+      - upstream-compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify required jobs succeeded
+        env:
+          BUILD_RESULT: ${{ needs.build-test-image.result }}
+          INTEGRATION_RESULT: ${{ needs.test-integration.result }}
+          SCAN_RESULT: ${{ needs.scan-image.result }}
+          FINAL_IMAGE_RESULT: ${{ needs.build-and-push-docker-image.result }}
+          HADOLINT_RESULT: ${{ needs.hadolint.result }}
+          SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
+          UPSTREAM_RESULT: ${{ needs.upstream-compatibility.result }}
+        run: |
+          failures=0
+
+          for result in \
+            "Build test image:$BUILD_RESULT" \
+            "Integration tests:$INTEGRATION_RESULT" \
+            "Security scan:$SCAN_RESULT" \
+            "Final image build:$FINAL_IMAGE_RESULT" \
+            "Hadolint:$HADOLINT_RESULT" \
+            "ShellCheck:$SHELLCHECK_RESULT" \
+            "Upstream compatibility:$UPSTREAM_RESULT"
+          do
+            name=${result%%:*}
+            status=${result#*:}
+            echo "$name: $status"
+
+            if [[ "$status" != "success" ]]; then
+              failures=1
+            fi
+          done
+
+          exit "$failures"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,25 @@
+name: Hadolint
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Dockerfile
+          # Package versions are intentionally unpinned for ca-certificates/wget
+          # (only apt-cacher-ng itself is version-pinned), so only fail on errors.
+          failure-threshold: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,22 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Lint bash scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run ShellCheck
+        run: |
+          # Find and lint all shell scripts
+          find . -name "*.sh" -not -path "*/\.*" -print0 | xargs -0 shellcheck

--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -1,9 +1,7 @@
 name: Upstream Compatibility Tests
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
   schedule:
     # Run weekly to catch upstream changes
     - cron: "0 8 * * 1"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,19 +4,19 @@ set -e
 create_pid_dir() {
   mkdir -p /run/apt-cacher-ng
   chmod -R 0755 /run/apt-cacher-ng
-  chown ${APT_CACHER_NG_USER}:${APT_CACHER_NG_USER} /run/apt-cacher-ng
+  chown "${APT_CACHER_NG_USER}":"${APT_CACHER_NG_USER}" /run/apt-cacher-ng
 }
 
 create_cache_dir() {
-  mkdir -p ${APT_CACHER_NG_CACHE_DIR}
-  chmod -R 0755 ${APT_CACHER_NG_CACHE_DIR}
-  chown -R ${APT_CACHER_NG_USER}:root ${APT_CACHER_NG_CACHE_DIR}
+  mkdir -p "${APT_CACHER_NG_CACHE_DIR}"
+  chmod -R 0755 "${APT_CACHER_NG_CACHE_DIR}"
+  chown -R "${APT_CACHER_NG_USER}":root "${APT_CACHER_NG_CACHE_DIR}"
 }
 
 create_log_dir() {
-  mkdir -p ${APT_CACHER_NG_LOG_DIR}
-  chmod -R 0755 ${APT_CACHER_NG_LOG_DIR}
-  chown -R ${APT_CACHER_NG_USER}:${APT_CACHER_NG_USER} ${APT_CACHER_NG_LOG_DIR}
+  mkdir -p "${APT_CACHER_NG_LOG_DIR}"
+  chmod -R 0755 "${APT_CACHER_NG_LOG_DIR}"
+  chown -R "${APT_CACHER_NG_USER}":"${APT_CACHER_NG_USER}" "${APT_CACHER_NG_LOG_DIR}"
 }
 
 create_pid_dir
@@ -25,17 +25,17 @@ create_log_dir
 
 # allow arguments to be passed to apt-cacher-ng
 if [[ ${1:0:1} = '-' ]]; then
-  EXTRA_ARGS="$@"
+  EXTRA_ARGS=("$@")
   set --
 elif [[ ${1} == apt-cacher-ng || ${1} == $(command -v apt-cacher-ng) ]]; then
-  EXTRA_ARGS="${@:2}"
+  EXTRA_ARGS=("${@:2}")
   set --
 fi
 
 # default behaviour is to launch apt-cacher-ng
 if [[ -z ${1} ]]; then
-  exec start-stop-daemon --start --chuid ${APT_CACHER_NG_USER}:${APT_CACHER_NG_USER} \
-    --exec "$(command -v apt-cacher-ng)" -- -c /etc/apt-cacher-ng ${EXTRA_ARGS}
+  exec start-stop-daemon --start --chuid "${APT_CACHER_NG_USER}":"${APT_CACHER_NG_USER}" \
+    --exec "$(command -v apt-cacher-ng)" -- -c /etc/apt-cacher-ng "${EXTRA_ARGS[@]}"
 else
   exec "$@"
 fi


### PR DESCRIPTION
## Summary
- Fixes pre-existing ShellCheck warnings in `entrypoint.sh` (quoting, `EXTRA_ARGS` as an array) so ShellCheck passes cleanly.
- Adds `hadolint.yml` and `shellcheck.yml` as reusable workflows (`workflow_call`, plus `push` to `main`).
- Converts `upstream-compatibility.yml` to `workflow_call` + `schedule` + `workflow_dispatch`, dropping its direct `pull_request` trigger.
- `build.yml` now invokes Hadolint, ShellCheck, and Upstream Compatibility Tests as PR-only reusable-workflow jobs (least-privilege permissions, no secrets), and adds a `pr-ci-gate` job (`PR CI Gate`) that `needs` every required job and fails unless all results are `success`.

This gives every PR a single stable `PR CI Gate` check instead of ~8+ independent contexts spread across four separate workflow runs, which is what will let `c-gerke/software`'s Terraform safely require CI via `require_ci = true` / `ci_gate_context` (issue oct8l/apt-cacher-ng#96 in `c-gerke/software`).

Note: `scan-image`'s Trivy step currently uses `exit-code: 0`, so it doesn't actually block on HIGH/CRITICAL CVEs today — the gate treats "Security scan" as required, but that job will report success regardless of findings until that's changed separately.

## Test plan
- [ ] Confirm this PR shows exactly one `PR CI Gate` check alongside the individual job checks.
- [ ] Confirm `PR CI Gate` waits for build, integration (both platforms), scan, final image build, Hadolint, ShellCheck, and Upstream Compatibility Tests.
- [ ] Confirm a deliberate failure in one of those jobs fails `PR CI Gate` rather than leaving it skipped/pending.