### PR TITLE
Make CI fork-safe and update testing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,10 @@ jobs:
     # Skip this job for scheduled builds (use the comprehensive one instead)
     if: github.event_name != 'schedule'
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,9 @@ jobs:
           context: .
           tags: local-apt-cacher-ng:test
           outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.artifact }}.tar
-          cache-from: type=gha,scope=${{ matrix.artifact }}
+          cache-from: |
+            type=gha
+            type=gha,scope=${{ matrix.artifact }}
           cache-to: type=gha,mode=max,scope=${{ matrix.artifact }}
           platforms: ${{ matrix.platform }}
 
@@ -346,7 +348,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          cache-from: |
+            type=gha
+            type=gha,scope=test-image-amd64
+            type=gha,scope=test-image-arm64
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 
@@ -395,7 +400,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          cache-from: |
+            type=gha
+            type=gha,scope=test-image-amd64
+            type=gha,scope=test-image-arm64
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,51 +16,18 @@ on:
 jobs:
 
   build-test-image:
-    name: Build Image for Testing & Scanning
+    name: Build test image (${{ matrix.platform }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    permissions:
-      packages: write
-
-    steps:
-
-      - name: Checkout git repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push to GHCR
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/oct8l/apt-cacher-ng:${{ github.run_id }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-
-  test-integration:
-    name: Integration tests (${{ matrix.platform }})
-    needs: [build-test-image]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     strategy:
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-
+        include:
+          - platform: linux/amd64
+            artifact: test-image-amd64
+          - platform: linux/arm64
+            artifact: test-image-arm64
     permissions:
-      packages: read
+      contents: read
 
     steps:
 
@@ -73,12 +40,58 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - name: Build and export test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          tags: local-apt-cacher-ng:test
+          outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.artifact }}.tar
+          cache-from: type=gha,scope=${{ matrix.artifact }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.artifact }}
+          platforms: ${{ matrix.platform }}
+
+      - name: Upload test image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}/${{ matrix.artifact }}.tar
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+  test-integration:
+    name: Integration tests (${{ matrix.platform }})
+    needs: [build-test-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifact: test-image-amd64
+          - platform: linux/arm64
+            artifact: test-image-arm64
+
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout git repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Download test image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}
+
+      - name: Load test image
+        run: docker load --input "${{ runner.temp }}/${{ matrix.artifact }}.tar"
+
       - name: Show platform info
         run: |
           echo "Testing on platform: ${{ matrix.platform }}"
@@ -93,7 +106,7 @@ jobs:
         run: |
           echo "Checking that the Dockerfile's sed overrides actually took effect..."
           docker run --rm --platform ${{ matrix.platform }} --entrypoint sh \
-            ghcr.io/oct8l/apt-cacher-ng:${{ github.run_id }} -c '
+            local-apt-cacher-ng:test -c '
               grep -q "^ForeGround: 1" /etc/apt-cacher-ng/acng.conf || { echo "ERROR: ForeGround override missing from acng.conf"; exit 1; }
               grep -q "^PassThroughPattern: .* #" /etc/apt-cacher-ng/acng.conf || { echo "ERROR: PassThroughPattern override missing from acng.conf"; exit 1; }
               echo "Config overrides present"
@@ -102,7 +115,7 @@ jobs:
       - name: Start services and run tests
         run: |
           echo "Starting apt-cacher-ng service..."
-          export TEST_IMAGE=ghcr.io/oct8l/apt-cacher-ng:${{ github.run_id }}
+          export TEST_IMAGE=local-apt-cacher-ng:test
           export TEST_PLATFORM=${{ matrix.platform }}
           docker compose -f docker-compose.test.yml up -d
 
@@ -141,25 +154,25 @@ jobs:
     timeout-minutes: 45
 
     permissions:
-      packages: read
+      contents: read
 
     steps:
       - name: Checkout git repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - name: Download test image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: test-image-amd64
+          path: ${{ runner.temp }}
+
+      - name: Load test image
+        run: docker load --input "${{ runner.temp }}/test-image-amd64.tar"
+
       - name: Start comprehensive test environment
         run: |
           echo "Starting comprehensive test environment..."
-          export TEST_IMAGE=ghcr.io/oct8l/apt-cacher-ng:${{ github.run_id }}
+          export TEST_IMAGE=local-apt-cacher-ng:test
           docker compose -f docker-compose.cron-test.yml up -d
 
           echo "Waiting for services to be healthy..."
@@ -231,7 +244,6 @@ jobs:
 
       permissions:
         contents: read
-        packages: read
         security-events: write
 
       steps:
@@ -239,20 +251,19 @@ jobs:
         - name: Checkout git repo
           uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-        - name: Login to ghcr.io registry
-          uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        - name: Download test image
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+            name: test-image-amd64
+            path: ${{ runner.temp }}
 
-        - name: Pull image to scan
-          run: docker pull ghcr.io/oct8l/apt-cacher-ng:"$GITHUB_RUN_ID"
+        - name: Load test image
+          run: docker load --input "${{ runner.temp }}/test-image-amd64.tar"
 
         - name: Run Trivy for HIGH,CRITICAL CVEs and report (blocking)
           uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master
           with:
-            image-ref: ghcr.io/oct8l/apt-cacher-ng:${{ github.run_id }}
+            image-ref: local-apt-cacher-ng:test
             exit-code: 1
             ignore-unfixed: true
             vuln-type: 'os,library'
@@ -261,7 +272,7 @@ jobs:
             output: 'results.sarif'
 
         - name: Upload Trivy scan results to GitHub Security tab
-          if: always()
+          if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
           uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
           with:
             sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
   - [Docker Compose](#docker-compose)
   - [Usage](#usage)
   - [Logs](#logs)
+- [Testing](#testing)
+  - [Local tests](#local-tests)
+  - [Pull request CI](#pull-request-ci)
+  - [Other CI runs](#other-ci-runs)
 - [Maintenance](#maintenance)
   - [Cache expiry](#cache-expiry)
   - [Upgrading](#upgrading)
@@ -29,6 +33,11 @@ Apt-Cacher NG is a caching proxy, specialized for package files from Linux distr
 If you find this image useful here's how you can help:
 
 - Send a pull request with your awesome features and bug fixes
+
+Fork-based contributions are supported. Create a branch in your fork, make your
+changes, run [`./test-local.sh`](#local-tests), and open a pull request against
+`main`. GitHub may require a maintainer to approve the first workflow run from a
+new contributor.
 
 ## Issues
 
@@ -149,45 +158,64 @@ docker exec -it apt-cacher-ng tail -f /var/log/apt-cacher-ng/apt-cacher.log
 
 # Testing
 
-## Local Testing
+## Local tests
 
-Before submitting a PR, you can run local tests to verify your changes work correctly:
+The local test suite requires Docker with the Compose plugin. It builds the
+image for your machine's architecture and uses
+[`docker-compose.test.yml`](docker-compose.test.yml) to run the same functional,
+performance, and error-handling scripts used by the main CI workflow.
 
 ```bash
 ./test-local.sh
 ```
 
-This script will:
-- Build the Docker image from your local changes
-- Start the apt-cacher-ng service
-- Run functional tests to verify package caching works
-- Test performance (cache miss vs cache hit)
-- Verify health checks and statistics
+The script verifies package downloads through the proxy, the health and report
+pages, multiple package installs, and handling of a nonexistent package. It
+also repeats package downloads to exercise the cache and records performance
+timings. The tests access upstream package repositories and may download
+several packages.
 
-## CI/CD Testing
+## Pull request CI
 
-The project includes comprehensive GitHub Actions workflows that run automatically on PRs:
+[`build.yml`](.github/workflows/build.yml) runs the following checks for pull
+requests targeting `main`:
 
-### Integration Tests (`build.yml`)
-- Builds the image from PR changes
-- Tests actual package downloads through the proxy
-- Verifies caching functionality works correctly
-- Tests error handling scenarios
-- Collects performance metrics and logs
+- Builds test images for `linux/amd64` and `linux/arm64`, then passes them to
+  downstream jobs as short-lived workflow artifacts. Pull requests do not push
+  test images or release images to GHCR, so the workflow can run for
+  contributions from forks without package-write permission.
+- Runs the functional, performance, error-handling, and configuration-override
+  checks on both test-image architectures.
+- Runs a blocking Trivy scan for fixable `HIGH` and `CRITICAL`
+  vulnerabilities. Fork pull requests run the same scan but do not upload its
+  SARIF report to the repository's Security tab, which requires write
+  permission.
+- Verifies that the final image builds for `linux/amd64`, `linux/arm64/v8`, and
+  `linux/arm/v7` without publishing it.
+- Runs Hadolint against the `Dockerfile` and ShellCheck against all tracked
+  shell scripts.
+- Runs the upstream compatibility workflow against Debian Bookworm (full and
+  slim) and Bullseye slim base images on AMD64 and ARM64. It uses the default
+  `apt-cacher-ng` version available from each base image's repositories.
+- Tests Debian Bookworm and Bullseye plus Ubuntu 24.04 and 22.04 clients,
+  additional package sources, and cache performance.
 
-### Upstream Compatibility Tests (`upstream-compatibility.yml`)
-- Tests against different Debian base images (`bookworm`, `bullseye`)
-- Tests with different apt-cacher-ng versions
-- Verifies compatibility with various client distributions (Debian, Ubuntu)
-- Tests different package sources and repositories
-- Runs performance regression testing
-- Scheduled weekly to catch upstream changes
+The `PR CI Gate` job aggregates these checks into a single status that branch
+protection can require.
 
-These automated tests ensure that:
-- Upstream image changes don't silently break builds
-- New changes maintain backward compatibility
-- Performance doesn't regress
-- The proxy works correctly across different client configurations
+## Other CI runs
+
+- Pushes to `main`, version tags, and manual `build.yml` runs execute the
+  integration and security checks before publishing the multi-architecture
+  image to GHCR.
+- On the 1st and 15th of each month,
+  [`build.yml`](.github/workflows/build.yml) adds comprehensive tests with
+  Debian Bookworm, Debian Bullseye, and Ubuntu 22.04 clients, plus load and
+  reliability tests, before publishing.
+- Every Monday,
+  [`upstream-compatibility.yml`](.github/workflows/upstream-compatibility.yml)
+  runs independently to detect changes in upstream distributions and package
+  repositories.
 
 # Maintenance
 


### PR DESCRIPTION
## Summary

- Build separate AMD64 and ARM64 test images and pass them between jobs as short-lived workflow artifacts instead of pushing temporary images to GHCR.
- Load those artifacts in the integration, scheduled comprehensive, and Trivy jobs while keeping official GHCR publishing unchanged for trusted non-PR runs.
- Keep the blocking Trivy scan on fork pull requests, but skip the Security-tab SARIF upload when the pull request token cannot have write permission.
- Rewrite the README contribution and testing guidance to match the current local suite, PR CI gate, architecture coverage, compatibility matrix, scheduled runs, and publishing behavior.

## Why

Fork-originated `pull_request` workflows receive a read-only `GITHUB_TOKEN`. The previous test-image job always requested `packages: write` and pushed to the hard-coded upstream GHCR namespace, so external contributors could not get through CI. Making the registry name dynamic would not solve the underlying permission restriction. The SARIF upload had the same write-permission problem for fork pull requests.

The README had also drifted from the implemented workflows. It described multiple apt-cacher-ng version tests and performance regression enforcement that do not currently exist, while omitting newer checks such as Hadolint, ShellCheck, the aggregate PR CI gate, current client distributions, and the distinction between PR validation and scheduled publishing.

## Impact

Fork-based contributions can run the complete build, integration, compatibility, and blocking vulnerability checks without registry write access. Only the repository Security-tab upload is skipped for fork pull requests. The official `ghcr.io/oct8l/apt-cacher-ng` publishing destination and release behavior are unchanged.

## Validation

- `./test-local.sh` on ARM64
- CI-style Buildx Docker tar export, load, architecture inspection, and configuration checks
- `docker compose config -q` for both test Compose files
- `actionlint -shellcheck= .github/workflows/*.yml`
- `shellcheck test-local.sh entrypoint.sh tests/*.sh`
- `git diff --check`