### PR TITLE
chore: update to Debian Trixie and expand compatibility testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,20 +206,20 @@ jobs:
 
       - name: Run load and stress tests
         run: |
-          echo "Running load test on Debian Bookworm..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim /tests/load_test.sh
+          echo "Running load test..."
+          docker compose -f docker-compose.cron-test.yml exec -T debian-trixie-slim /tests/load_test.sh
 
       - name: Run reliability tests
         run: |
           echo "Running reliability test..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim /tests/reliability_test.sh
+          docker compose -f docker-compose.cron-test.yml exec -T debian-trixie-slim /tests/reliability_test.sh
 
       - name: Validate proxy statistics and health
         run: |
           echo "=== Final Proxy Validation ==="
 
           # Get detailed statistics
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim curl -f -s "http://apt-cacher-ng:3142/acng-report.html" > proxy-stats.html
+          docker compose -f docker-compose.cron-test.yml exec -T debian-trixie-slim curl -f -s "http://apt-cacher-ng:3142/acng-report.html" > proxy-stats.html
 
           # Check for expected content in statistics
           if ! grep -q -i "apt-cacher" proxy-stats.html; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,34 +188,38 @@ jobs:
 
       - name: Run multi-distribution tests
         run: |
-          echo "Testing Debian Trixie..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-trixie /tests/multi_distro_test.sh
-
-          echo "Testing Debian Bookworm..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm /tests/multi_distro_test.sh
-
-          echo "Testing Debian Bullseye..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bullseye /tests/multi_distro_test.sh
-
-          echo "Testing Ubuntu Jammy..."
-          docker compose -f docker-compose.cron-test.yml exec -T ubuntu-jammy /tests/multi_distro_test.sh
+          clients=(
+            debian-trixie-slim
+            debian-trixie
+            debian-bookworm-slim
+            debian-bookworm
+            debian-bullseye-slim
+            debian-bullseye
+            ubuntu-26-04
+            ubuntu-24-04
+            ubuntu-22-04
+          )
+          for client in "${clients[@]}"; do
+            echo "Testing ${client}..."
+            docker compose -f docker-compose.cron-test.yml exec -T "${client}" /tests/multi_distro_test.sh
+          done
 
       - name: Run load and stress tests
         run: |
           echo "Running load test on Debian Bookworm..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm /tests/load_test.sh
+          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim /tests/load_test.sh
 
       - name: Run reliability tests
         run: |
           echo "Running reliability test..."
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm /tests/reliability_test.sh
+          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim /tests/reliability_test.sh
 
       - name: Validate proxy statistics and health
         run: |
           echo "=== Final Proxy Validation ==="
 
           # Get detailed statistics
-          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm curl -f -s "http://apt-cacher-ng:3142/acng-report.html" > proxy-stats.html
+          docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm-slim curl -f -s "http://apt-cacher-ng:3142/acng-report.html" > proxy-stats.html
 
           # Check for expected content in statistics
           if ! grep -q -i "apt-cacher" proxy-stats.html; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ on:
   schedule:
     - cron: '30 5 1,15 * *'
 
+env:
+  FINAL_IMAGE_CACHE_FROM: |
+    type=gha
+    type=gha,scope=test-image-amd64
+    type=gha,scope=test-image-arm64
+
 jobs:
 
   build-test-image:
@@ -348,10 +354,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha
-            type=gha,scope=test-image-amd64
-            type=gha,scope=test-image-arm64
+          cache-from: ${{ env.FINAL_IMAGE_CACHE_FROM }}
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 
@@ -404,10 +407,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha
-            type=gha,scope=test-image-amd64
-            type=gha,scope=test-image-arm64
+          cache-from: ${{ env.FINAL_IMAGE_CACHE_FROM }}
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,6 +366,10 @@ jobs:
     # Only run this job for scheduled builds (after comprehensive testing)
     if: github.event_name == 'schedule'
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,9 @@ jobs:
 
       - name: Run multi-distribution tests
         run: |
+          echo "Testing Debian Trixie..."
+          docker compose -f docker-compose.cron-test.yml exec -T debian-trixie /tests/multi_distro_test.sh
+
           echo "Testing Debian Bookworm..."
           docker compose -f docker-compose.cron-test.yml exec -T debian-bookworm /tests/multi_distro_test.sh
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -20,6 +20,4 @@ jobs:
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile
-          # Package versions are intentionally unpinned for ca-certificates/wget
-          # (only apt-cacher-ng itself is version-pinned), so only fail on errors.
-          failure-threshold: error
+          failure-threshold: warning

--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
+          - "debian:trixie-slim"
+          - "debian:trixie"
           - "debian:bookworm-slim"
           - "debian:bookworm"
           - "debian:bullseye-slim"
@@ -205,6 +207,7 @@ jobs:
       fail-fast: false
       matrix:
         client_image:
+          - "debian:trixie"
           - "debian:bookworm"
           - "debian:bullseye"
           - "ubuntu:24.04"

--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -21,6 +21,7 @@ jobs:
           - "debian:bookworm-slim"
           - "debian:bookworm"
           - "debian:bullseye-slim"
+          - "debian:bullseye"
         apt_cacher_version:
           - "" # Use default version available in the repository
           # Additional versions can be added when we know they exist in specific repos
@@ -199,7 +200,7 @@ jobs:
           docker compose -f docker-compose.upstream-test.yml down
 
   test-different-debian-clients:
-    name: Test compatibility with different Debian client versions (${{ matrix.client_image }})
+    name: Test compatibility with different client distributions (${{ matrix.client_image }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [test-upstream-variations]
@@ -207,9 +208,13 @@ jobs:
       fail-fast: false
       matrix:
         client_image:
+          - "debian:trixie-slim"
           - "debian:trixie"
+          - "debian:bookworm-slim"
           - "debian:bookworm"
+          - "debian:bullseye-slim"
           - "debian:bullseye"
+          - "ubuntu:26.04"
           - "ubuntu:24.04"
           - "ubuntu:22.04"
 

--- a/.github/workflows/upstream-compatibility.yml
+++ b/.github/workflows/upstream-compatibility.yml
@@ -133,27 +133,55 @@ jobs:
           # Sanitize matrix values for Docker tag (replace : and / with -)
           BASE_TAG=$(echo "${{ matrix.base_image }}" | sed 's/[:/]/-/g')
           VERSION_TAG=$(echo "$VERSION_DISPLAY" | sed 's/[:/]/-/g')
+
+          cleanup() {
+            docker stop test-cacher >/dev/null 2>&1 || true
+            docker rm test-cacher >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
           # Start the service
           docker run -d --name test-cacher -p 3142:3142 test-apt-cacher:${BASE_TAG}-${VERSION_TAG}
 
           # Wait for service to be ready
           timeout 60s bash -c 'while ! curl -f -s http://localhost:3142/acng-report.html > /dev/null; do sleep 2; done'
 
-          # Test that we can use it as a proxy
-          docker run --rm --add-host=apt-cacher:host-gateway debian:bookworm-slim bash -c "
-            echo 'Acquire::HTTP::Proxy \"http://apt-cacher:3142\";' > /etc/apt/apt.conf.d/01proxy
-            echo 'Acquire::HTTPS::Proxy \"false\";' >> /etc/apt/apt.conf.d/01proxy
-            apt-get update
-            apt-get install -y curl
-            curl --version
-          "
+          # Retry apt through the proxy on transient upstream/proxy 5xx (e.g. 502)
+          max_attempts=3
+          attempt=1
+          while true; do
+            echo "Proxy client test attempt ${attempt}/${max_attempts}..."
+            set +e
+            output=$(docker run --rm --add-host=apt-cacher:host-gateway debian:bookworm-slim bash -c '
+              echo "Acquire::HTTP::Proxy \"http://apt-cacher:3142\";" > /etc/apt/apt.conf.d/01proxy
+              echo "Acquire::HTTPS::Proxy \"false\";" >> /etc/apt/apt.conf.d/01proxy
+              echo "Acquire::Retries \"3\";" >> /etc/apt/apt.conf.d/01proxy
+              apt-get update
+              apt-get install -y curl
+              curl --version
+            ' 2>&1)
+            status=$?
+            set -e
+            printf '%s\n' "$output"
+
+            if [[ $status -eq 0 ]]; then
+              break
+            fi
+
+            if [[ $attempt -lt $max_attempts ]] && grep -qE '[[:space:]]5[0-9]{2}[[:space:]]' <<<"$output"; then
+              sleep_for=$((attempt * 5))
+              echo "Transient HTTP 5xx from upstream/proxy; retrying in ${sleep_for}s..."
+              sleep "$sleep_for"
+              attempt=$((attempt + 1))
+              continue
+            fi
+
+            echo "Proxy client test failed (exit ${status})"
+            exit "$status"
+          done
 
           # Verify health
           curl -f http://localhost:3142/acng-report.html
-
-          # Cleanup
-          docker stop test-cacher
-          docker rm test-cacher
 
       - name: Test with docker-compose
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
+# Package pins use a trailing * at install time so Debian binNMU suffixes
+# (e.g. 3.7.5-1 on amd64 vs 3.7.5-1+b1 on arm64) still match. Renovate only
+# looks up amd64 versions (see renovate.json), so ENV values are amd64 revisions.
 # renovate: suite=trixie depName=apt-cacher-ng
 ENV APT_CACHER_NG_VERSION="3.7.5-1"
 # renovate: suite=trixie depName=ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
-ENV APT_CACHER_NG_VERSION=3.7.4 \
-    APT_CACHER_NG_CACHE_DIR=/var/cache/apt-cacher-ng \
+# renovate: suite=trixie depName=apt-cacher-ng
+ENV APT_CACHER_NG_VERSION="3.7.5-1"
+# renovate: suite=trixie depName=ca-certificates
+ENV CA_CERTIFICATES_VERSION="20250419"
+# renovate: suite=trixie depName=wget
+ENV WGET_VERSION="1.25.0-2"
+
+ENV APT_CACHER_NG_CACHE_DIR=/var/cache/apt-cacher-ng \
     APT_CACHER_NG_LOG_DIR=/var/log/apt-cacher-ng \
     APT_CACHER_NG_USER=apt-cacher-ng
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-      apt-cacher-ng=${APT_CACHER_NG_VERSION}* ca-certificates wget \
+      "apt-cacher-ng=${APT_CACHER_NG_VERSION}*" \
+      "ca-certificates=${CA_CERTIFICATES_VERSION}" \
+      "wget=${WGET_VERSION}" \
  && sed 's/# ForeGround: 0/ForeGround: 1/' -i /etc/apt-cacher-ng/acng.conf \
  && sed 's/# PassThroughPattern:.*this would allow.*/PassThroughPattern: .* #/' -i /etc/apt-cacher-ng/acng.conf \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV APT_CACHER_NG_CACHE_DIR=/var/cache/apt-cacher-ng \
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
       "apt-cacher-ng=${APT_CACHER_NG_VERSION}*" \
-      "ca-certificates=${CA_CERTIFICATES_VERSION}" \
-      "wget=${WGET_VERSION}" \
+      "ca-certificates=${CA_CERTIFICATES_VERSION}*" \
+      "wget=${WGET_VERSION}*" \
  && sed 's/# ForeGround: 0/ForeGround: 1/' -i /etc/apt-cacher-ng/acng.conf \
  && sed 's/# PassThroughPattern:.*this would allow.*/PassThroughPattern: .* #/' -i /etc/apt-cacher-ng/acng.conf \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ To run Apt-Cacher NG with Docker Compose, create the following `docker-compose.y
 
 ```yaml
 ---
-version: '3'
-
 services:
   apt-cacher-ng:
     image: ghcr.io/oct8l/apt-cacher-ng:latest

--- a/README.md
+++ b/README.md
@@ -192,11 +192,12 @@ requests targeting `main`:
   `linux/arm/v7` without publishing it.
 - Runs Hadolint against the `Dockerfile` and ShellCheck against all tracked
   shell scripts.
-- Runs the upstream compatibility workflow against Debian Bookworm (full and
-  slim) and Bullseye slim base images on AMD64 and ARM64. It uses the default
-  `apt-cacher-ng` version available from each base image's repositories.
-- Tests Debian Bookworm and Bullseye plus Ubuntu 24.04 and 22.04 clients,
-  additional package sources, and cache performance.
+- Runs the upstream compatibility workflow against Debian Trixie (full and
+  slim), Bookworm (full and slim), and Bullseye slim base images on AMD64 and
+  ARM64. It uses the default `apt-cacher-ng` version available from each base
+  image's repositories.
+- Tests Debian Trixie, Bookworm, and Bullseye plus Ubuntu 24.04 and 22.04
+  clients, additional package sources, and cache performance.
 
 The `PR CI Gate` job aggregates these checks into a single status that branch
 protection can require.
@@ -208,8 +209,8 @@ protection can require.
   image to GHCR.
 - On the 1st and 15th of each month,
   [`build.yml`](.github/workflows/build.yml) adds comprehensive tests with
-  Debian Bookworm, Debian Bullseye, and Ubuntu 22.04 clients, plus load and
-  reliability tests, before publishing.
+  Debian Trixie, Debian Bookworm, Debian Bullseye, and Ubuntu 22.04 clients,
+  plus load and reliability tests, before publishing.
 - Every Monday,
   [`upstream-compatibility.yml`](.github/workflows/upstream-compatibility.yml)
   runs independently to detect changes in upstream distributions and package

--- a/README.md
+++ b/README.md
@@ -192,12 +192,11 @@ requests targeting `main`:
   `linux/arm/v7` without publishing it.
 - Runs Hadolint against the `Dockerfile` and ShellCheck against all tracked
   shell scripts.
-- Runs the upstream compatibility workflow against Debian Trixie (full and
-  slim), Bookworm (full and slim), and Bullseye slim base images on AMD64 and
-  ARM64. It uses the default `apt-cacher-ng` version available from each base
-  image's repositories.
-- Tests Debian Trixie, Bookworm, and Bullseye plus Ubuntu 24.04 and 22.04
-  clients, additional package sources, and cache performance.
+- Runs the upstream compatibility workflow against Debian Trixie, Bookworm, and
+  Bullseye (full and slim for each) base images on AMD64 and ARM64. It uses the
+  default `apt-cacher-ng` version available from each base image's repositories.
+- Tests Debian Trixie, Bookworm, and Bullseye (full and slim) plus Ubuntu 26.04,
+  24.04, and 22.04 clients, additional package sources, and cache performance.
 
 The `PR CI Gate` job aggregates these checks into a single status that branch
 protection can require.
@@ -209,8 +208,8 @@ protection can require.
   image to GHCR.
 - On the 1st and 15th of each month,
   [`build.yml`](.github/workflows/build.yml) adds comprehensive tests with
-  Debian Trixie, Debian Bookworm, Debian Bullseye, and Ubuntu 22.04 clients,
-  plus load and reliability tests, before publishing.
+  Debian Trixie/Bookworm/Bullseye (full and slim) and Ubuntu 26.04/24.04/22.04
+  clients, plus load and reliability tests, before publishing.
 - Every Monday,
   [`upstream-compatibility.yml`](.github/workflows/upstream-compatibility.yml)
   runs independently to detect changes in upstream distributions and package

--- a/docker-compose.cron-test.yml
+++ b/docker-compose.cron-test.yml
@@ -15,6 +15,15 @@ services:
       start_period: 30s
 
   # Test multiple distributions
+  debian-trixie:
+    image: debian:trixie-slim
+    depends_on:
+      apt-cacher-ng:
+        condition: service_healthy
+    volumes:
+      - ./tests:/tests
+    command: sleep infinity
+
   debian-bookworm:
     image: debian:bookworm-slim
     depends_on:

--- a/docker-compose.cron-test.yml
+++ b/docker-compose.cron-test.yml
@@ -14,42 +14,48 @@ services:
       retries: 5
       start_period: 30s
 
-  # Test multiple distributions
-  debian-trixie:
+  # Client images for multi-distribution tests
+  debian-trixie-slim:
+    <<: &client
+      depends_on:
+        apt-cacher-ng:
+          condition: service_healthy
+      volumes:
+        - ./tests:/tests
+      command: sleep infinity
     image: debian:trixie-slim
-    depends_on:
-      apt-cacher-ng:
-        condition: service_healthy
-    volumes:
-      - ./tests:/tests
-    command: sleep infinity
+
+  debian-trixie:
+    <<: *client
+    image: debian:trixie
+
+  debian-bookworm-slim:
+    <<: *client
+    image: debian:bookworm-slim
 
   debian-bookworm:
-    image: debian:bookworm-slim
-    depends_on:
-      apt-cacher-ng:
-        condition: service_healthy
-    volumes:
-      - ./tests:/tests
-    command: sleep infinity
+    <<: *client
+    image: debian:bookworm
+
+  debian-bullseye-slim:
+    <<: *client
+    image: debian:bullseye-slim
 
   debian-bullseye:
-    image: debian:bullseye-slim
-    depends_on:
-      apt-cacher-ng:
-        condition: service_healthy
-    volumes:
-      - ./tests:/tests
-    command: sleep infinity
+    <<: *client
+    image: debian:bullseye
 
-  ubuntu-jammy:
+  ubuntu-26-04:
+    <<: *client
+    image: ubuntu:26.04
+
+  ubuntu-24-04:
+    <<: *client
+    image: ubuntu:24.04
+
+  ubuntu-22-04:
+    <<: *client
     image: ubuntu:22.04
-    depends_on:
-      apt-cacher-ng:
-        condition: service_healthy
-    volumes:
-      - ./tests:/tests
-    command: sleep infinity
 
 volumes:
   apt-cacher-data:

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Track Debian package versions in the Dockerfile. binaryArch=amd64 is intentional: one pin per package, with install-time * wildcards covering other arches' +bN binNMU suffixes.",
       "managerFilePatterns": [
         "/^Dockerfile$/"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,19 @@
   "extends": [
     "github>c-gerke/renovate-config"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Dockerfile$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*suite=(?<suite>\\S+)\\s+depName=(?<depName>\\S+)\\s+ENV\\s+\\S+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "registryUrlTemplate": "https://deb.debian.org/debian?suite={{suite}}&components=main&binaryArch=amd64",
+      "datasourceTemplate": "deb"
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
## Summary

- update the runtime base image from pinned `debian:bookworm-slim` to pinned `debian:trixie-slim`
- update Apt-Cacher NG to Trixie's `3.7.5-1` package and pin every directly installed APT package
- add Renovate annotations and a Debian datasource custom manager for `apt-cacher-ng`, `ca-certificates`, and `wget`
- expand compatibility coverage across full and slim Debian Trixie, Bookworm, and Bullseye images on AMD64 and ARM64
- expand scheduled client coverage to those Debian variants plus Ubuntu 26.04, 24.04, and 22.04
- harden CI with cleanup traps and bounded retries for transient upstream or proxy HTTP 5xx responses
- consolidate final-image cache inputs and grant the scheduled publish job the package permissions it requires
- make Hadolint fail on warnings and update the README for the revised test coverage and modern Docker Compose syntax

## Why

The image was still based on Bookworm and kept Apt-Cacher NG at `3.7.4` until someone changed the Dockerfile manually. Moving to Trixie updates the runtime baseline, while Renovate tracking makes Debian package updates visible as normal dependency PRs.

The compatibility and scheduled test matrices now reflect the supported distribution range around the new base image. The CI changes also reduce duplication, fix scheduled publishing permissions, ensure test containers are cleaned up on failure, and retry only transient HTTP 5xx failures that can occur while exercising upstream repositories through the proxy.

## Package version behavior

Package installs keep a trailing version wildcard because Debian can append architecture-specific binary rebuild suffixes. For example, Apt-Cacher NG is currently `3.7.5-1` on AMD64 and `3.7.5-1+b1` on ARM64.

Renovate uses the AMD64 Trixie package index as the canonical pin source, while the install-time wildcard allows equivalent `+bN` revisions on the other published architectures.

## Validation

- `./test-local.sh`
- Docker builds for `linux/amd64` and `linux/arm64`
- Hadolint with `failure-threshold: warning`
- Renovate strict configuration validation
- Renovate local extraction and Debian package lookup for all three tracked packages
- GitHub Actions multi-architecture builds, integration tests, linting, image scans, and expanded upstream compatibility matrix
