### PR TITLE
Fix Trivy severity filter in security scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
             ignore-unfixed: true
             vuln-type: 'os,library'
             severity: 'HIGH,CRITICAL'
+            limit-severities-for-sarif: true
             format: 'sarif'
             output: 'results.sarif'
 


### PR DESCRIPTION
## Summary

`scan-image` fails intermittently on false-severity grounds: the job is configured to gate only on `HIGH`/`CRITICAL` findings with an available fix, but actually gates on every severity down to `UNKNOWN`/`LOW`. Reproduced on the failing run at [31844808548](https://github.com/oct8l/apt-cacher-ng/actions/runs/31844808548/job/94909030928), which failed on three `util-linux` CVEs that are `MEDIUM`/`LOW`, not `HIGH`/`CRITICAL`. Same root cause as [oct8l/lancache#71](https://github.com/oct8l/lancache/pull/71) — this workflow was the pattern that one was originally modeled on (see `lancache`'s `release.yml` comment crediting this repo).

## Root cause

[`aquasecurity/trivy-action`'s entrypoint](https://github.com/aquasecurity/trivy-action/blob/master/entrypoint.sh) unsets `TRIVY_SEVERITY` whenever `format: sarif` unless `limit-severities-for-sarif: true` is explicitly set:

```bash
if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
  if [ "${INPUT_LIMIT_SEVERITIES_FOR_SARIF:-false,,}" != "true" ]; then
    echo "Building SARIF report with all severities"
    unset TRIVY_SEVERITY
```

Since the SARIF output and the `exit-code` gate come from the same Trivy invocation, `severity: 'HIGH,CRITICAL'` at [`.github/workflows/build.yml#L285`](https://github.com/oct8l/apt-cacher-ng/blob/0f308559fb1382544611e30a9f7fe27f63495c47/.github/workflows/build.yml#L278-L287) was silently discarded for both the report *and* the blocking decision. Confirmed two ways:

- The failing run's log prints `Building SARIF report with all severities` on the Trivy step, the literal string that code path emits.
- All 21 currently-open code-scanning alerts on this repo are `MEDIUM` or `LOW`: `CVE-2026-13595` and `CVE-2026-27456` (both MEDIUM, `util-linux`, fixed in `2.41.5-0+deb13u1`) and `CVE-2025-14104` (LOW, `util-linux`, fixed in `2.41.3-1`). None are `HIGH`/`CRITICAL` — the configured threshold should have excluded all of them.

## Approach

One-line fix: add `limit-severities-for-sarif: true` next to the existing `severity: 'HIGH,CRITICAL'` input. This is `trivy-action`'s own documented flag for exactly this behavior — no change to what the job is supposed to gate on, just makes the actual behavior match the configured `severity` input.

Nothing else about this repo's setup needed touching. Unlike `lancache`, this workflow already runs `scan-image` on `pull_request` (no restrictive `if:`, and `pr-ci-gate` already requires it), so there's no PR-gating gap here. And unlike `lancache`'s externally-cloned, infrequently-updated base Dockerfile, this repo's `FROM debian:trixie-slim@sha256:...` is digest-pinned and Renovate-bumped directly, with the three installed packages also Renovate-tracked via `# renovate: suite=trixie depName=...` — any real patch bump changes the Dockerfile text itself, which naturally invalidates the build cache, so there's no equivalent stale-cache risk to patch around here.

## Tested

- [x] `actionlint .github/workflows/build.yml` clean.
- [x] Full-repo `actionlint` shows the same 24 pre-existing `SC2086` info-level findings in `upstream-compatibility.yml` on both `main` and this branch (verified via `git stash`/`git stash pop`) — nothing new introduced by this change.
- [x] `git diff --check` clean.
- [x] `README.md`'s existing description of this job ("Runs a blocking Trivy scan for fixable `HIGH` and `CRITICAL` vulnerabilities") already describes the *intended* behavior correctly — this was an implementation gap, not a documentation gap, so no doc changes needed.

## Needs human verification before merge

- [ ] **Watch the actual run on this PR.** The fix has been validated with `actionlint` and against the failing run's log/alerts, but hasn't executed for real — confirm `scan-image` now reports the three `util-linux` findings as non-blocking (or doesn't gate on them at all) and still correctly blocks on a genuine HIGH/CRITICAL finding if one exists.
- [ ] **Decide whether the three currently-open `util-linux` findings need any follow-up.** They're MEDIUM/LOW so this fix alone stops them from blocking anything, but they're still open findings with fixes available (`2.41.5-0+deb13u1` / `2.41.3-1`) — confirm whether picking those up is expected to happen automatically via the existing Renovate digest-pin flow on `debian:trixie-slim`, or whether it needs a manual nudge.
